### PR TITLE
add success bool to make inline with other services

### DIFF
--- a/rr_custom_msgs/srv/SetMode.srv
+++ b/rr_custom_msgs/srv/SetMode.srv
@@ -1,3 +1,4 @@
 rr_custom_msgs/Mode set_mode
 ---
-string response
+bool success
+string message


### PR DESCRIPTION
This PR modifies the SetMode service so that it returns a success bool and renames the string to be message to match our other services and the standard services 